### PR TITLE
Rewriting Ternoa Fundamentals denominations

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ For your first examples you can check our [CookBook](https://docs.ternoa.network
 
 ### Docmap
 
-- [ ] [Ternoa Fundamentals](https://github.com/capsule-corp-ternoa/ternoa-doc/blob/main/docs/intro.md#-ternoa-fundamentals)
+- [ ] [Ternoa Wiki](https://github.com/capsule-corp-ternoa/ternoa-doc/blob/main/docs/intro.md#-ternoa-wiki)
     - [ ] [Core Blockchain](https://docs.ternoa.network/category/core-blockchain)
     - [ ] [Offchain Components](https://docs.ternoa.network/category/offchain-components)
     - [ ] [TEE Enclaves](https://docs.ternoa.network/category/tee-enclaves)

--- a/docs/for-developers/indexer/dictionary/index.md
+++ b/docs/for-developers/indexer/dictionary/index.md
@@ -5,7 +5,7 @@ sidebar_label: Overview
 
 # Overview
 
-If you already looked at our documentation, you should now [understand](/ternoa-fundamentals/offchain-components/builder-tools/dictionary) that the indexing datas provided by the chain can be retrieved both on our (**[alphanet indexer](https://indexer-alphanet.ternoa.dev/)** or **[mainnet indexer](https://indexer-mainnet.ternoa.network/)**), but also on our [dictionary](https://dictionary-mainnet.ternoa.dev/). 
+If you already looked at our documentation, you should now [understand](/ternoa-wiki/offchain-components/builder-tools/dictionary) that the indexing datas provided by the chain can be retrieved both on our (**[alphanet indexer](https://indexer-alphanet.ternoa.dev/)** or **[mainnet indexer](https://indexer-mainnet.ternoa.network/)**), but also on our [dictionary](https://dictionary-mainnet.ternoa.dev/). 
 
 Since the [Dictionary](/for-developers/#what-are-the-differences-between-the-dictionary-or-the-indexer) is focused on native substrate on-chain data contained in **blocks**, (instead of being focused on listening events like the indexer), you can use it for : 
 - [Installing](/for-developers/indexer/dictionary/use-dictionary) it into your own indexer as we do to improve performance.

--- a/docs/fundamentals/_category_.json
+++ b/docs/fundamentals/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Fundamentals",
+  "label": "Wiki",
   "position": 3,
   "link": {
     "type": "generated-index"

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -23,7 +23,7 @@ sidebar_label: 👋 Welcome
 >
 > Creating NFTs and building dApps on most blockchains is complex. Ternoa was designed to break barriers for developers, web3 enthusiasts, and entrepreneurs and empower them to save time and money. We believe mass adoption of NFTs is only possible with a fundamental tech evolution. In this guide, we have developed a range of tools to walk you through how to use and build on Ternoa for the first time. 
 
-## 📚 Ternoa Fundamentals
+## 📚 Ternoa Wiki
 
 Review below to learn the core foundation of the blockchain architecture, offchain components, trusted execution environment, and NFT specifications. 
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -142,8 +142,8 @@ const config = {
                 to: '/intro',
               },
               {
-                label: 'Ternoa Fundamentals',
-                to: '/category/fundamentals',
+                label: 'Ternoa Wiki',
+                to: '/category/wiki',
               },
               {
                 label: 'For Developers',

--- a/i18n/fr/docusaurus-plugin-content-docs/current.json
+++ b/i18n/fr/docusaurus-plugin-content-docs/current.json
@@ -3,14 +3,14 @@
     "message": "Next",
     "description": "The label for version current"
   },
-  "sidebar.tutorialSidebar.category.Ternoa Fundamentals": {
-    "message": "Ternoa Fondamentaux",
-    "description": "The label for category Ternoa Fundamentals in sidebar tutorialSidebar"
+  "sidebar.tutorialSidebar.category.Ternoa Wiki": {
+    "message": "Ternoa Wiki",
+    "description": "The label for category Ternoa Wiki in sidebar tutorialSidebar"
   },
 
-  "sidebar.tutorialSidebar.category.Ternoa Fundamentals.link.generated-index.description": {
+  "sidebar.tutorialSidebar.category.Ternoa Wiki.link.generated-index.description": {
     "message": "Tout ce que vous devez savoir",
-    "description": "The generated-index page description for category Ternoa Fundamentals in sidebar tutorialSidebar"
+    "description": "The generated-index page description for category Ternoa Wiki in sidebar tutorialSidebar"
   },
   "sidebar.tutorialSidebar.category.Core Blockchain": {
     "message": "Core Blockchain",

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -12,7 +12,7 @@ type FeatureItem = {
 
 const FeatureList: FeatureItem[] = [
   {
-    title: 'Ternoa fundamentals',
+    title: 'Ternoa Wiki',
     icon: '🔎',
     description: (
       <>
@@ -21,7 +21,7 @@ const FeatureList: FeatureItem[] = [
         and get new experience with creation, minting and trading NFTs.
       </>
     ),
-    url: '/category/fundamentals'
+    url: '/category/wiki'
   },
   
   {


### PR DESCRIPTION
Changing all designations of "Fundamentals" with Ternoa "Wiki" instead